### PR TITLE
refactor: 엔티티를 도메인 모델 클래스로 분리

### DIFF
--- a/src/main/java/com/rebook/book/domain/Book.java
+++ b/src/main/java/com/rebook/book/domain/Book.java
@@ -1,0 +1,18 @@
+package com.rebook.book.domain;
+
+import com.rebook.review.domain.Review;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class Book {
+
+    private final Long id;
+    private final String title;
+    private final String author;
+    private final String thumbnailUrl;
+    private final List<Review> reviews;
+}

--- a/src/main/java/com/rebook/book/domain/BookHashtag.java
+++ b/src/main/java/com/rebook/book/domain/BookHashtag.java
@@ -1,0 +1,4 @@
+package com.rebook.book.domain;
+
+public class BookHashtag {
+}

--- a/src/main/java/com/rebook/book/domain/entity/BookEntity.java
+++ b/src/main/java/com/rebook/book/domain/entity/BookEntity.java
@@ -1,4 +1,4 @@
-package com.rebook.book.domain;
+package com.rebook.book.domain.entity;
 
 import com.rebook.common.domain.BaseEntity;
 import com.rebook.review.domain.ReviewEntity;

--- a/src/main/java/com/rebook/book/domain/entity/BookEntity.java
+++ b/src/main/java/com/rebook/book/domain/entity/BookEntity.java
@@ -10,11 +10,12 @@ import org.hibernate.annotations.Comment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-@Entity
-@Table(name = "book")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "book")
+@Entity
 public class BookEntity extends BaseEntity {
 
     private static final String DEFAULT_IMAGE_NAME = "default_image.jpeg";
@@ -39,7 +40,7 @@ public class BookEntity extends BaseEntity {
     @OneToMany
     private List<ReviewEntity> reviews = new ArrayList<>();
 
-    public BookEntity(
+    private BookEntity(
             final Long id,
             final String title,
             final String author,
@@ -65,6 +66,6 @@ public class BookEntity extends BaseEntity {
     }
 
     public String getThumbnailUrl() {
-        return thumbnailUrl != null ? thumbnailUrl : DEFAULT_IMAGE_NAME;
+        return Objects.requireNonNullElse(thumbnailUrl, DEFAULT_IMAGE_NAME);
     }
 }

--- a/src/main/java/com/rebook/book/domain/entity/BookHashtagEntity.java
+++ b/src/main/java/com/rebook/book/domain/entity/BookHashtagEntity.java
@@ -11,11 +11,11 @@ public class BookHashtagEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
     private BookEntity book;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hashtag_id")
     private HashtagEntity hashTag;
 }

--- a/src/main/java/com/rebook/book/domain/entity/BookHashtagEntity.java
+++ b/src/main/java/com/rebook/book/domain/entity/BookHashtagEntity.java
@@ -1,4 +1,4 @@
-package com.rebook.book.domain;
+package com.rebook.book.domain.entity;
 
 import com.rebook.hashtag.domain.HashtagEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/rebook/book/dto/response/BookResponse.java
+++ b/src/main/java/com/rebook/book/dto/response/BookResponse.java
@@ -1,6 +1,6 @@
 package com.rebook.book.dto.response;
 
-import com.rebook.book.domain.BookEntity;
+import com.rebook.book.domain.entity.BookEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/rebook/book/repository/BookRepository.java
+++ b/src/main/java/com/rebook/book/repository/BookRepository.java
@@ -1,6 +1,6 @@
 package com.rebook.book.repository;
 
-import com.rebook.book.domain.BookEntity;
+import com.rebook.book.domain.entity.BookEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<BookEntity, Long> {

--- a/src/main/java/com/rebook/book/service/BookService.java
+++ b/src/main/java/com/rebook/book/service/BookService.java
@@ -1,6 +1,6 @@
 package com.rebook.book.service;
 
-import com.rebook.book.domain.BookEntity;
+import com.rebook.book.domain.entity.BookEntity;
 import com.rebook.book.dto.response.BookResponse;
 import com.rebook.book.dto.request.BookCreateRequest;
 import com.rebook.book.repository.BookRepository;

--- a/src/main/java/com/rebook/hashtag/domain/HashtagEntity.java
+++ b/src/main/java/com/rebook/hashtag/domain/HashtagEntity.java
@@ -10,10 +10,10 @@ import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Where(clause = "is_deleted = false")
 @SQLDelete(sql = "UPDATE hashtag SET is_deleted = true WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "hashtag")
 @Entity
 public class HashtagEntity extends BaseEntity {

--- a/src/main/java/com/rebook/review/service/ReviewService.java
+++ b/src/main/java/com/rebook/review/service/ReviewService.java
@@ -17,14 +17,15 @@ public class ReviewService {
     public ReviewService(ReviewRepository reviewRepository) {
         this.reviewRepository = reviewRepository;
     }
+
     @Transactional
-    public Review save(ReviewRequest reviewRequest){
+    public Review save(ReviewRequest reviewRequest) {
         ReviewEntity reviewEntity = ReviewEntity.of(reviewRequest);
         ReviewEntity savedReview = reviewRepository.save(reviewEntity);
         return Review.of(savedReview);
     }
 
-    public List<Review> getReviews(){
+    public List<Review> getReviews() {
         List<ReviewEntity> reviews = reviewRepository.findAll();
         return reviews.stream()
                 .map(Review::of)


### PR DESCRIPTION
- 현재는 엔티티의 역할이 데이터베이스 레이어의 역할과 비즈니스 로직 수행 역할 두 가지의 역할을 담당하고 있다.
- 이를 엔티티 클래스는 데이터베이스와 통신하는 역할만을 하게 정리하고,
- 도메인 모델 클래스를 추가하여 비즈니스 관련 로직은 해당 클래스가 처리하도록 구조를 변경하였다.